### PR TITLE
Fix config mistakes in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Mostly relevant for when you're transpiling with `tsc`. If you want to change th
 
 ```json
 {
-  "extends": "@total-typescript/tsconfig/tsc/node/library",
+  "extends": "@total-typescript/tsconfig/tsc/no-dom/library",
   "compilerOptions": {
     "outDir": "dist"
   }


### PR DESCRIPTION
This fixes a couple of mistakes in the README:

- ~The bundler configs don't have app/library/library-monorepo variants.~
- There no "node" variant (I'm assuming that what "no-dom" used to be called).