### PR TITLE
fix: remove redundant options

### DIFF
--- a/bundler/dom.json
+++ b/bundler/dom.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
     /* Base Options: */
-    "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
     "allowJs": true,
-    "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
     "verbatimModuleSyntax": true,

--- a/bundler/no-dom.json
+++ b/bundler/no-dom.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
     /* Base Options: */
-    "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es2022",
     "allowJs": true,
-    "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
This PR removes the following redundant TypeScript compiler options:

* `esModuleInterop`
* `resolveJsonModule`

These options are implicitly enabled when using `"module": "preserve"` since TypeScript 5.4 ([see announcement](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#support-for-require-calls-in---moduleresolution-bundler-and---module-preserve)). Removing them simplifies the configuration and reduces unnecessary complexity.

This is a non-breaking change.